### PR TITLE
feat(deps): configuration for renovate bot

### DIFF
--- a/.github/workflows/renovate-validator.yml
+++ b/.github/workflows/renovate-validator.yml
@@ -1,0 +1,17 @@
+name: Renovate Config Validation
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Validate
+        uses: rinchsan/renovate-config-validator@v0.0.8
+        with:
+          pattern: 'renovate.json' # Regular expression for filename to validate, default to *.json

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "extends": [
-    "config:base"
-  ]
+    "config:base",
+    "schedule:weekends",
+    "npm:unpublishSafe"
+  ],
+  "prConcurrentLimit": 5
 }


### PR DESCRIPTION
Following adjustments were made with this meaning:
`config:base`: 
```
":dependencyDashboard",
    ":semanticPrefixFixDepsChoreOthers",
    ":ignoreModulesAndTests",
    ":autodetectPinVersions",
    ":prHourlyLimit2",
    ":prConcurrentLimit20",
    "group:monorepos",
    "group:recommended",
    "workarounds:all"
``` 
`schedule:weekends`: Renovate runs "every weekend"

`npm:unpublishSafe`: Set a status check pending for 3 days from release timestamp to guard against npm unpublishing

`prConcurrentLimit: 5`: Only 5 PRs in parallel